### PR TITLE
Implement Auto-Merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,17 @@
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:20"
-  open-pull-requests-limit: 10
-  target-branch: main
-  labels:
-    - "dependency"
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "04:20"
+    open-pull-requests-limit: 10
+    target-branch: main
+    labels:
+      - "dependency"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    auto-merge:
+      enabled: true
+      method: squash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Implementing auto-merge for dependabot PRs [#12](https://github.com/ie3-institute/copernicusWeather2psdmWeather/issues/12)
+### Changed
+
+### Fixed
+
+### Removed


### PR DESCRIPTION
Closes #12 

This pull request introduces a configuration change to the `.github/dependabot.yml` file, specifically focusing on dependency updates. The most important changes include ignoring major version updates for dependencies and enabling automatic merging with the squash method.

Changes to dependency update configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R12-R17): Added a rule to ignore major version updates for all dependencies.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R12-R17): Enabled automatic merging of dependency updates using the squash method.