### PR TITLE
Fixing implementation of Dependabot Auto-Merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,3 @@ updates:
     target-branch: main
     labels:
       - "dependency"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    auto-merge:
-      enabled: true
-      method: squash

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,26 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'ie3-institute/copernicusWeather2psdmWeather'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' || 
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-
+- Fixed implementation of dependabot auto-merge feature [#14](https://github.com/ie3-institute/copernicusWeather2psdmWeather/issues/14)
 ### Removed


### PR DESCRIPTION
Closes #14 

This pull request includes changes to improve the dependabot auto-merge feature and update the configuration files accordingly. The most important changes include removing the ignore and auto-merge settings from `.github/dependabot.yml`, adding a new workflow for dependabot auto-merge, and updating the changelog to reflect these changes.

Configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L12-L17): Removed the ignore and auto-merge settings to streamline the configuration.

New workflow:

* [`.github/workflows/dependabot-auto-merge.yml`](diffhunk://#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1R1-R26): Added a new workflow to handle auto-merging of dependabot pull requests based on specific conditions.

Changelog update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL14-R14): Updated to include a note about the fixed implementation of the dependabot auto-merge feature.