### PR TITLE
Remove minor auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,9 +17,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Enable auto-merge for Dependabot PRs
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' || 
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Implementing auto-merge for dependabot PRs [#12](https://github.com/ie3-institute/copernicusWeather2psdmWeather/issues/12)
+
 ### Changed
+- Disabled auto-merge for minor Dependabot updates [#20](https://github.com/ie3-institute/copernicusWeather2psdmWeather/issues/20)
 
 ### Fixed
 - Fixed implementation of dependabot auto-merge feature [#14](https://github.com/ie3-institute/copernicusWeather2psdmWeather/issues/14)
+
 ### Removed


### PR DESCRIPTION
Closes #20 

This pull request includes a small change to the `.github/workflows/dependabot-auto-merge.yml` file. The change modifies the conditions under which auto-merge is enabled for Dependabot pull requests.

* [`.github/workflows/dependabot-auto-merge.yml`](diffhunk://#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1L20-R20): Updated the `if` condition to enable auto-merge only for `version-update:semver-patch` updates, removing the condition for `version-update:semver-minor` updates.